### PR TITLE
feature: add --settings option 

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const puppeteer = require('puppeteer');
 const argv = yargs
   .string('package')
   .string('release')
+  .string('settings')
   .string('test-app-path')
   .boolean('once')
   .boolean('inspect')
@@ -67,7 +68,10 @@ function startMeteor (port) {
     args.push('--inspect-brk');
   }
   if (argv.testAppPath) {
-    args.push('--test-app-path', argv.testAppPath)
+    args.push('--test-app-path', argv.testAppPath);
+  }
+  if (argv.settings) {
+    args.push('--settings', argv.settings);
   }
   
   if (/^win/.test(process.platform)) {


### PR DESCRIPTION
Running package tests that require Meteor settings to be present (some package hard-rely on Meteor.settings) requires this arg to be parsed and added to the launch args. This PR makes this possible. Should not introduce any further regressions.